### PR TITLE
Dockerized the front end of the interns portal

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,6 @@
+version : '2'
+services:
+  web:
+    build: './web'
+    ports :
+      - "3000 : 3000"

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,2 @@
+bower-components
+node_modules

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:boron
+
+WORKDIR /usr/src/app
+
+COPY package.json .
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm","start"]

--- a/web/package.json
+++ b/web/package.json
@@ -44,7 +44,8 @@
     "wrench": "~1.5.8"
   },
   "scripts": {
-    "postinstall": "bower install"
+    "postinstall": "bower install",
+    "start" : "gulp serve"
   },
   "dependencies": {
     "knockout": "^3.4.0",


### PR DESCRIPTION
When dockerizing the interns portal, we have to take in to account, the architecture of the interns portal. Therefore as far as intern portal is concerned we can only dockerize the front-end of the application. This pull request contains the docker config for the web front-end of the interns portal.